### PR TITLE
PHP 5.3 compatibility

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -15,7 +15,7 @@
     }
   ],
   "require": {
-    "php": ">=5.4"
+    "php": ">=5.3"
   },
   "require-dev": {
     "phpunit/phpunit": "~4.0",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at http://getcomposer.org/doc/01-basic-usage.md#composer-lock-the-lock-file",
         "This file is @generated automatically"
     ],
-    "hash": "3cb3b320ff8857995319e933a2cb677f",
+    "hash": "cc6783e7988291f4d16973c4460bf448",
     "packages": [],
     "packages-dev": [
         {
@@ -1267,7 +1267,7 @@
     },
     "prefer-stable": false,
     "platform": {
-        "php": ">=5.4"
+        "php": ">=5.3"
     },
     "platform-dev": []
 }

--- a/src/Implementations/ArraySort.php
+++ b/src/Implementations/ArraySort.php
@@ -108,10 +108,10 @@ class ArraySort extends BaseImplementation implements TopSortInterface
      */
     public function doSort()
     {
-        $this->sorted = [];
+        $this->sorted = array();
 
         foreach ($this->elements as $element) {
-            $parents = [];
+            $parents = array();
             $this->visit($element, $parents);
         }
 

--- a/src/Implementations/BaseImplementation.php
+++ b/src/Implementations/BaseImplementation.php
@@ -27,7 +27,7 @@ abstract class BaseImplementation
     /**
      * @param callable $circularInterceptor
      */
-    public function setCircularInterceptor(callable $circularInterceptor)
+    public function setCircularInterceptor($circularInterceptor)
     {
         $this->circularInterceptor = $circularInterceptor;
     }

--- a/src/Implementations/FixedArraySort.php
+++ b/src/Implementations/FixedArraySort.php
@@ -46,7 +46,7 @@ class FixedArraySort extends ArraySort
         $this->sorted = new \SplFixedArray(count($this->elements));
 
         foreach ($this->elements as $element) {
-            $parents = [];
+            $parents = array();
             $this->visit($element, $parents);
         }
 

--- a/src/Implementations/GroupedArraySort.php
+++ b/src/Implementations/GroupedArraySort.php
@@ -47,7 +47,7 @@ class GroupedArraySort extends BaseImplementation implements GroupedTopSortInter
             $this->add(
                 $element,
                 $typeAndDependencies[0],
-                isset($typeAndDependencies[1]) ? $typeAndDependencies[1] : []
+                isset($typeAndDependencies[1]) ? $typeAndDependencies[1] : array()
             );
         }
     }
@@ -113,12 +113,12 @@ class GroupedArraySort extends BaseImplementation implements GroupedTopSortInter
             }
             $element->addedAtLevel = $group->level;
         } else {
-            $this->groups[] = (object)[
+            $this->groups[] = (object)array(
                 'type' => $element->type,
                 'level' => $this->groupLevel,
                 'position' => $this->position,
                 'length' => 1
-            ];
+            );
             $element->addedAtLevel = $this->groupLevel;
             $this->sorted[] = $element->id;
             $this->position++;
@@ -189,10 +189,10 @@ class GroupedArraySort extends BaseImplementation implements GroupedTopSortInter
      */
     public function doSort()
     {
-        $this->sorted = [];
+        $this->sorted = array();
 
         foreach ($this->elements as $element) {
-            $parents = [];
+            $parents = array();
             $this->visit($element, $parents);
         }
 

--- a/src/Implementations/GroupedFixedArraySort.php
+++ b/src/Implementations/GroupedFixedArraySort.php
@@ -30,12 +30,12 @@ class GroupedFixedArraySort extends GroupedArraySort
 
             $element->addedAtLevel = $group->level;
         } else {
-            $this->groups[] = (object)[
+            $this->groups[] = (object)array(
                 'type' => $element->type,
                 'level' => $this->groupLevel,
                 'position' => $this->position,
                 'length' => 1
-            ];
+            );
             $element->addedAtLevel = $this->groupLevel;
             $this->sorted[$this->position] = $element->id;
             $this->position++;
@@ -78,7 +78,7 @@ class GroupedFixedArraySort extends GroupedArraySort
         $this->sorted = new \SplFixedArray(count($this->elements));
 
         foreach ($this->elements as $element) {
-            $parents = [];
+            $parents = array();
             $this->visit($element, $parents);
         }
 

--- a/src/Implementations/GroupedStringSort.php
+++ b/src/Implementations/GroupedStringSort.php
@@ -33,13 +33,13 @@ class GroupedStringSort extends GroupedArraySort
             $element->addedAtLevel = $group->level;
         } else {
             //just append this element at the end
-            $group = (object)[
+            $group = (object)array(
                 'type' => $element->type,
                 'level' => $this->groupLevel,
                 'position' => $this->position,
                 'length' => 1,
                 'sorted' => ''
-            ];
+            );
             $this->groups[] = $group;
             $element->addedAtLevel = $this->groupLevel;
 
@@ -98,7 +98,7 @@ class GroupedStringSort extends GroupedArraySort
         $this->sorted = '';
 
         foreach ($this->elements as $element) {
-            $parents = [];
+            $parents = array();
             $this->visit($element, $parents);
         }
 

--- a/src/Implementations/StringSort.php
+++ b/src/Implementations/StringSort.php
@@ -75,7 +75,7 @@ class StringSort extends ArraySort
         $this->sorted = '';
 
         foreach ($this->elements as $element) {
-            $parents = [];
+            $parents = array();
             $this->visit($element, $parents);
         }
 

--- a/src/TopSortInterface.php
+++ b/src/TopSortInterface.php
@@ -43,7 +43,7 @@ interface TopSortInterface
     /**
      * @param callable $circularInterceptor
      */
-    public function setCircularInterceptor(callable $circularInterceptor);
+    public function setCircularInterceptor($circularInterceptor);
 
     /**
      * @return boolean

--- a/tests/Tests/GroupedSortTest.php
+++ b/tests/Tests/GroupedSortTest.php
@@ -14,11 +14,11 @@ class GroupedSortTest extends \PHPUnit_Framework_TestCase
 
     public function provideImplementations()
     {
-        return [
-            [new GroupedArraySort()],
-            [new GroupedStringSort()],
-            [new GroupedFixedArraySort()]
-        ];
+        return array(
+            array(new GroupedArraySort()),
+            array(new GroupedStringSort()),
+            array(new GroupedFixedArraySort())
+        );
     }
 
     /**
@@ -30,8 +30,8 @@ class GroupedSortTest extends \PHPUnit_Framework_TestCase
      */
     public function testCircular(GroupedTopSortInterface $sorter)
     {
-        $sorter->add('car1', 'bar', ['owner1']);
-        $sorter->add('owner1', 'owner', ['car1']);
+        $sorter->add('car1', 'bar', array('owner1'));
+        $sorter->add('owner1', 'owner', array('car1'));
         $sorter->sort();
     }
 
@@ -43,11 +43,11 @@ class GroupedSortTest extends \PHPUnit_Framework_TestCase
     public function testDisabledCircularException(GroupedTopSortInterface $sorter)
     {
         $sorter->setThrowCircularDependency(false);
-        $sorter->add('car1', ['owner1']);
-        $sorter->add('owner1', ['car1']);
+        $sorter->add('car1', array('owner1'));
+        $sorter->add('owner1', array('car1'));
         $result = $sorter->sort();
 
-        $this->assertEquals(['car1', 'owner1'], $result);
+        $this->assertEquals(array('car1', 'owner1'), $result);
     }
 
     /**
@@ -60,8 +60,8 @@ class GroupedSortTest extends \PHPUnit_Framework_TestCase
     public function testNotFound(GroupedTopSortInterface $sorter)
     {
         $sorter->setThrowCircularDependency(true);
-        $sorter->add('car1', 'car', ['owner1']);
-        $sorter->add('owner1', 'owner', ['car2']);
+        $sorter->add('car1', 'car', array('owner1'));
+        $sorter->add('owner1', 'owner', array('car2'));
         $sorter->sort();
     }
 
@@ -73,15 +73,15 @@ class GroupedSortTest extends \PHPUnit_Framework_TestCase
     public function testNotCircularException(GroupedTopSortInterface $sorter)
     {
         $sorter->setThrowCircularDependency(true);
-        $sorter->add('car1', 'car', ['owner1']);
-        $sorter->add('owner1', 'owner', ['brand1']);
-        $sorter->add('brand1', 'brand', ['car1']);
+        $sorter->add('car1', 'car', array('owner1'));
+        $sorter->add('owner1', 'owner', array('brand1'));
+        $sorter->add('brand1', 'brand', array('car1'));
 
         try {
             $sorter->sort();
             $this->fail('This must fail');
         } catch( CircularDependencyException $e ) {
-            $this->assertEquals(['car1', 'owner1', 'brand1'], $e->getNodes());
+            $this->assertEquals(array('car1', 'owner1', 'brand1'), $e->getNodes());
             $this->assertEquals('car1', $e->getStart());
             $this->assertEquals('brand1', $e->getEnd());
         }
@@ -89,15 +89,15 @@ class GroupedSortTest extends \PHPUnit_Framework_TestCase
 
     public function testConstructor()
     {
-        $elements = [
-            'car1' => ['car', ['brand1']],
-            'car2' => ['car', ['brand2']],
-            'brand1' => ['brand'],
-            'brand2' => ['brand']
-        ];
+        $elements = array(
+            'car1' => array('car', array('brand1')),
+            'car2' => array('car', array('brand2')),
+            'brand1' => array('brand'),
+            'brand2' => array('brand')
+        );
         $sorter = new GroupedArraySort($elements, true);
         $this->assertTrue($sorter->isThrowCircularDependency());
-        $this->assertEquals(['brand1', 'brand2', 'car1', 'car2'], $sorter->sort());
+        $this->assertEquals(array('brand1', 'brand2', 'car1', 'car2'), $sorter->sort());
     }
 
     /**
@@ -108,8 +108,8 @@ class GroupedSortTest extends \PHPUnit_Framework_TestCase
     public function testNotFoundException(GroupedTopSortInterface $sorter)
     {
         $sorter->setThrowCircularDependency(true);
-        $sorter->add('car1', 'car', ['owner1']);
-        $sorter->add('owner1', 'owner', ['car2']);
+        $sorter->add('car1', 'car', array('owner1'));
+        $sorter->add('owner1', 'owner', array('car2'));
 
         $this->assertEquals(true, $sorter->isThrowCircularDependency());
 
@@ -129,10 +129,10 @@ class GroupedSortTest extends \PHPUnit_Framework_TestCase
      */
     public function testImplementationsSimple2(GroupedTopSortInterface $sorter)
     {
-        $sorter->add('car1', 'car', ['brand1']);
+        $sorter->add('car1', 'car', array('brand1'));
         $sorter->add('brand1', 'brand');
         $sorter->add('car2', 'car');
-        $sorter->add('brand2', 'brand', ['car2']);
+        $sorter->add('brand2', 'brand', array('car2'));
 
         $result = $sorter->sort();
         $expected = explode(', ', 'brand1, car1, car2, brand2');
@@ -146,11 +146,11 @@ class GroupedSortTest extends \PHPUnit_Framework_TestCase
      */
     public function testImplementationsGetGroups(GroupedTopSortInterface $sorter)
     {
-        $sorter->add('car1', 'car', ['owner1', 'brand1']);
+        $sorter->add('car1', 'car', array('owner1', 'brand1'));
         $sorter->add('brand1', 'brand');
         $sorter->add('brand2', 'brand');
-        $sorter->add('owner1', 'user', ['brand1']);
-        $sorter->add('owner2', 'user', ['brand2']);
+        $sorter->add('owner1', 'user', array('brand1'));
+        $sorter->add('owner2', 'user', array('brand2'));
 
         $result = $sorter->sort();
 
@@ -160,32 +160,32 @@ class GroupedSortTest extends \PHPUnit_Framework_TestCase
         $groups = $sorter->getGroups();
 
         $this->assertEquals(
-            [
+            array(
                 'type' => 'brand',
                 'level' => 0,
                 'position' => 0,
                 'length' => 2
-            ],
+            ),
             (array)$groups[0]
         );
 
         $this->assertEquals(
-            [
+            array(
                 'type' => 'user',
                 'level' => 1,
                 'position' => 2,
                 'length' => 2
-            ],
+            ),
             (array)$groups[1]
         );
 
         $this->assertEquals(
-            [
+            array(
                 'type' => 'car',
                 'level' => 2,
                 'position' => 4,
                 'length' => 1
-            ],
+            ),
             (array)$groups[2]
         );
 
@@ -203,11 +203,11 @@ class GroupedSortTest extends \PHPUnit_Framework_TestCase
      */
     public function testImplementationsSimpleDoc(GroupedTopSortInterface $sorter)
     {
-        $sorter->add('car1', 'car', ['owner1', 'brand1']);
+        $sorter->add('car1', 'car', array('owner1', 'brand1'));
         $sorter->add('brand1', 'brand');
         $sorter->add('brand2', 'brand');
-        $sorter->add('owner1', 'user', ['brand1']);
-        $sorter->add('owner2', 'user', ['brand2']);
+        $sorter->add('owner1', 'user', array('brand1'));
+        $sorter->add('owner2', 'user', array('brand2'));
 
         $result = $sorter->sort();
 
@@ -222,10 +222,10 @@ class GroupedSortTest extends \PHPUnit_Framework_TestCase
      */
     public function testImplementationsSimple(GroupedTopSortInterface $sorter)
     {
-        $sorter->add('car1', 'car', ['brand1']);
-        $sorter->add('owner1', 'owner', ['car1', 'brand1']);
-        $sorter->add('owner2', 'owner', ['car2', 'brand1']);
-        $sorter->add('car2', 'car', ['brand2']);
+        $sorter->add('car1', 'car', array('brand1'));
+        $sorter->add('owner1', 'owner', array('car1', 'brand1'));
+        $sorter->add('owner2', 'owner', array('car2', 'brand1'));
+        $sorter->add('car2', 'car', array('brand2'));
         $sorter->add('brand1', 'brand');
         $sorter->add('brand2', 'brand');
 
@@ -243,8 +243,8 @@ class GroupedSortTest extends \PHPUnit_Framework_TestCase
     public function testImplementations(GroupedTopSortInterface $sorter)
     {
         for ($i = 0; $i < 3; $i++) {
-            $sorter->add('car' . $i, 'car', ['owner' . $i, 'brand' . $i]);
-            $sorter->add('owner' . $i, 'owner', ['brand' . $i]);
+            $sorter->add('car' . $i, 'car', array('owner' . $i, 'brand' . $i));
+            $sorter->add('owner' . $i, 'owner', array('brand' . $i));
             $sorter->add('brand' . $i, 'brand');
         }
 
@@ -263,8 +263,8 @@ class GroupedSortTest extends \PHPUnit_Framework_TestCase
     {
         for ($i = 0; $i < 3; $i++) {
             $sorter->add('brand' . $i, 'brand');
-            $sorter->add('car' . $i, 'car', ['owner' . $i, 'brand' . $i]);
-            $sorter->add('owner' . $i, 'owner', ['brand' . $i]);
+            $sorter->add('car' . $i, 'car', array('owner' . $i, 'brand' . $i));
+            $sorter->add('owner' . $i, 'owner', array('brand' . $i));
         }
 
         $result = $sorter->sort();
@@ -282,8 +282,8 @@ class GroupedSortTest extends \PHPUnit_Framework_TestCase
     {
         for ($i = 0; $i < 3; $i++) {
             $sorter->add('brand' . $i, 'brand');
-            $sorter->add('owner' . $i, 'owner', ['brand' . $i]);
-            $sorter->add('car' . $i, 'car', ['owner' . $i, 'brand' . $i]);
+            $sorter->add('owner' . $i, 'owner', array('brand' . $i));
+            $sorter->add('car' . $i, 'car', array('owner' . $i, 'brand' . $i));
         }
 
         $result = $sorter->sort();
@@ -300,9 +300,9 @@ class GroupedSortTest extends \PHPUnit_Framework_TestCase
     public function testImplementations4(GroupedTopSortInterface $sorter)
     {
         for ($i = 0; $i < 3; $i++) {
-            $sorter->add('owner' . $i, 'owner', ['brand' . $i]);
+            $sorter->add('owner' . $i, 'owner', array('brand' . $i));
             $sorter->add('brand' . $i, 'brand');
-            $sorter->add('car' . $i, 'car', ['owner' . $i, 'brand' . $i]);
+            $sorter->add('car' . $i, 'car', array('owner' . $i, 'brand' . $i));
         }
 
         $result = $sorter->sort();

--- a/tests/Tests/SimpleSortTest.php
+++ b/tests/Tests/SimpleSortTest.php
@@ -14,11 +14,11 @@ class SimpleSortTest extends \PHPUnit_Framework_TestCase
 
     public function provideImplementations()
     {
-        return [
-            [new ArraySort()],
-            [new StringSort()],
-            [new FixedArraySort()]
-        ];
+        return array(
+            array(new ArraySort()),
+            array(new StringSort()),
+            array(new FixedArraySort())
+        );
     }
 
     /**
@@ -30,8 +30,8 @@ class SimpleSortTest extends \PHPUnit_Framework_TestCase
      */
     public function testCircular(TopSortInterface $sorter)
     {
-        $sorter->add('car1', ['owner1']);
-        $sorter->add('owner1', ['car1']);
+        $sorter->add('car1', array('owner1'));
+        $sorter->add('owner1', array('car1'));
         $sorter->sort();
     }
 
@@ -43,11 +43,11 @@ class SimpleSortTest extends \PHPUnit_Framework_TestCase
     public function testDisabledCircularException(TopSortInterface $sorter)
     {
         $sorter->setThrowCircularDependency(false);
-        $sorter->add('car1', ['owner1']);
-        $sorter->add('owner1', ['car1']);
+        $sorter->add('car1', array('owner1'));
+        $sorter->add('owner1', array('car1'));
         $result = $sorter->sort();
 
-        $this->assertEquals(['owner1', 'car1'], $result);
+        $this->assertEquals(array('owner1', 'car1'), $result);
     }
 
     /**
@@ -60,8 +60,8 @@ class SimpleSortTest extends \PHPUnit_Framework_TestCase
     public function testNotFound(TopSortInterface $sorter)
     {
         $sorter->setThrowCircularDependency(true);
-        $sorter->add('car1', ['owner1']);
-        $sorter->add('owner1', ['car2']);
+        $sorter->add('car1', array('owner1'));
+        $sorter->add('owner1', array('car2'));
         $sorter->sort();
     }
 
@@ -73,15 +73,15 @@ class SimpleSortTest extends \PHPUnit_Framework_TestCase
     public function testCircularException(TopSortInterface $sorter)
     {
         $sorter->setThrowCircularDependency(true);
-        $sorter->add('car1', ['owner1']);
-        $sorter->add('owner1', ['brand1']);
-        $sorter->add('brand1', ['car1']);
+        $sorter->add('car1', array('owner1'));
+        $sorter->add('owner1', array('brand1'));
+        $sorter->add('brand1', array('car1'));
 
         try {
             $sorter->sort();
             $this->fail('This must fail');
         } catch(CircularDependencyException $e) {
-            $this->assertEquals(['car1', 'owner1', 'brand1'], $e->getNodes());
+            $this->assertEquals(array('car1', 'owner1', 'brand1'), $e->getNodes());
             $this->assertEquals('car1', $e->getStart());
             $this->assertEquals('brand1', $e->getEnd());
         }
@@ -99,9 +99,9 @@ class SimpleSortTest extends \PHPUnit_Framework_TestCase
         $sorter->setCircularInterceptor(function() use (&$intercepted) {
             $intercepted = true;
         });
-        $sorter->add('car1', ['owner1']);
-        $sorter->add('owner1', ['brand1']);
-        $sorter->add('brand1', ['car1']);
+        $sorter->add('car1', array('owner1'));
+        $sorter->add('owner1', array('brand1'));
+        $sorter->add('brand1', array('car1'));
 
         $sorter->sort();
         $this->assertTrue($intercepted, 'Interception method must be called since a circular dependency has found');
@@ -109,10 +109,10 @@ class SimpleSortTest extends \PHPUnit_Framework_TestCase
 
     public function testConstructor()
     {
-        $elements = ['car1' => ['brand1'], 'car2' => ['brand2'], 'brand1' => [], 'brand2' => []];
+        $elements = array('car1' => array('brand1'), 'car2' => array('brand2'), 'brand1' => array(), 'brand2' => array());
         $sorter = new ArraySort($elements, true);
         $this->assertTrue($sorter->isThrowCircularDependency());
-        $this->assertEquals(['brand1', 'car1', 'brand2', 'car2'], $sorter->sort());
+        $this->assertEquals(array('brand1', 'car1', 'brand2', 'car2'), $sorter->sort());
     }
 
     /**
@@ -123,8 +123,8 @@ class SimpleSortTest extends \PHPUnit_Framework_TestCase
     public function testNotFoundException(TopSortInterface $sorter)
     {
         $sorter->setThrowCircularDependency(true);
-        $sorter->add('car1', ['owner1']);
-        $sorter->add('owner1', ['car2']);
+        $sorter->add('car1', array('owner1'));
+        $sorter->add('owner1', array('car2'));
 
         $this->assertEquals(true, $sorter->isThrowCircularDependency());
 
@@ -143,20 +143,20 @@ class SimpleSortTest extends \PHPUnit_Framework_TestCase
     public function testImplementationsBlub(TopSortInterface $sorter)
     {
         for ($i = 0; $i < 2; $i++) {
-            $sorter->add('car' . $i, ['owner' . $i, 'brand' . $i]);
-            $sorter->add('owner' . $i, ['brand' . $i]);
+            $sorter->add('car' . $i, array('owner' . $i, 'brand' . $i));
+            $sorter->add('owner' . $i, array('brand' . $i));
             $sorter->add('brand' . $i);
         }
 
-        $sorter->add('sellerX', ['brandX3']);
-        $sorter->add('brandY', ['sellerX', 'brandX2']);
+        $sorter->add('sellerX', array('brandX3'));
+        $sorter->add('brandY', array('sellerX', 'brandX2'));
         $sorter->add('brandX');
-        $sorter->add('brandX2', ['brandX', 'brandX3']);
+        $sorter->add('brandX2', array('brandX', 'brandX3'));
         $sorter->add('brandX3');
 
         $result = $sorter->sort();
 
-        $expected = [
+        $expected = array(
             'brand0',
             'owner0',
             'car0',
@@ -168,7 +168,7 @@ class SimpleSortTest extends \PHPUnit_Framework_TestCase
             'brandX',
             'brandX2',
             'brandY',
-        ];
+        );
 
         $this->assertEquals($expected, $result);
     }
@@ -178,11 +178,11 @@ class SimpleSortTest extends \PHPUnit_Framework_TestCase
      */
     public function testImplementationsSimpleDoc(TopSortInterface $sorter)
     {
-        $sorter->add('car1', ['owner1', 'brand1']);
+        $sorter->add('car1', array('owner1', 'brand1'));
         $sorter->add('brand1');
         $sorter->add('brand2');
-        $sorter->add('owner1', ['brand1']);
-        $sorter->add('owner2', ['brand2']);
+        $sorter->add('owner1', array('brand1'));
+        $sorter->add('owner2', array('brand2'));
 
         $result = $sorter->sort();
 
@@ -198,9 +198,9 @@ class SimpleSortTest extends \PHPUnit_Framework_TestCase
     {
 
         $sorter->add('brand1');
-        $sorter->add('car1', ['brand1']);
+        $sorter->add('car1', array('brand1'));
 
-        $sorter->add('car2', ['brand2']);
+        $sorter->add('car2', array('brand2'));
         $sorter->add('brand2');
 
         $result = $sorter->sort();
@@ -216,14 +216,14 @@ class SimpleSortTest extends \PHPUnit_Framework_TestCase
     public function testImplementations(TopSortInterface $sorter)
     {
         for ($i = 0; $i < 3; $i++) {
-            $sorter->add('car' . $i, ['owner' . $i, 'brand' . $i]);
-            $sorter->add('owner' . $i, ['brand' . $i]);
+            $sorter->add('car' . $i, array('owner' . $i, 'brand' . $i));
+            $sorter->add('owner' . $i, array('brand' . $i));
             $sorter->add('brand' . $i);
         }
 
         $result = $sorter->sort();
 
-        $expected = [
+        $expected = array(
             'brand0',
             'owner0',
             'car0',
@@ -233,7 +233,7 @@ class SimpleSortTest extends \PHPUnit_Framework_TestCase
             'brand2',
             'owner2',
             'car2'
-        ];
+        );
 
         $this->assertEquals($expected, $result);
     }
@@ -244,14 +244,14 @@ class SimpleSortTest extends \PHPUnit_Framework_TestCase
     public function testImplementations2(TopSortInterface $sorter)
     {
         for ($i = 0; $i < 3; $i++) {
-            $sorter->add('owner' . $i, ['brand' . $i]);
-            $sorter->add('car' . $i, ['owner' . $i, 'brand' . $i]);
+            $sorter->add('owner' . $i, array('brand' . $i));
+            $sorter->add('car' . $i, array('owner' . $i, 'brand' . $i));
             $sorter->add('brand' . $i);
         }
 
         $result = $sorter->sort();
 
-        $expected = [
+        $expected = array(
             'brand0',
             'owner0',
             'car0',
@@ -261,7 +261,7 @@ class SimpleSortTest extends \PHPUnit_Framework_TestCase
             'brand2',
             'owner2',
             'car2'
-        ];
+        );
 
         $this->assertEquals($expected, $result);
     }
@@ -272,14 +272,14 @@ class SimpleSortTest extends \PHPUnit_Framework_TestCase
     public function testImplementations3(TopSortInterface $sorter)
     {
         for ($i = 0; $i < 3; $i++) {
-            $sorter->add('owner' . $i, ['brand' . $i]);
+            $sorter->add('owner' . $i, array('brand' . $i));
             $sorter->add('brand' . $i);
-            $sorter->add('car' . $i, ['owner' . $i, 'brand' . $i]);
+            $sorter->add('car' . $i, array('owner' . $i, 'brand' . $i));
         }
 
         $result = $sorter->sort();
 
-        $expected = [
+        $expected = array(
             'brand0',
             'owner0',
             'car0',
@@ -289,7 +289,7 @@ class SimpleSortTest extends \PHPUnit_Framework_TestCase
             'brand2',
             'owner2',
             'car2'
-        ];
+        );
 
         $this->assertEquals($expected, $result);
     }


### PR DESCRIPTION
Thanks for posting this along with the benchmarks! Nicely done.

I'm trying to incorporate this as part of modernization in an older codebase, but we still have PHP 5.3 as part of the userbase. The main change is to use `array()` notation instead of `[]` notation.

There's one potential tricky bit in 6675a06 -- see the commit notes.

Locally checked the test-suite with the following combinations (and all passed):
- php 5.3 + phpunit 3.x
- php 5.4 + phpunit 4.x
- php 5.5 + phpunit 4.x

If you really don't want compatibility, feel free to close this. I can continue working off a fork.
