### PR TITLE
NEW: Add 2.x-dev alias for master

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -27,5 +27,10 @@
       "MJS\\TopSort\\": "src/",
       "MJS\\TopSort\\Tests\\": "tests/Tests/"
     }
+  },
+  "extra": {
+    "branch-alias": {
+        "dev-master": "2.x-dev"
+    }
   }
 }

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "7cb52b4d39006dcbbfcd30a541c39c99",
+    "content-hash": "f222ce0b1691080017c3f700a42a8c36",
     "packages": [],
     "packages-dev": [
         {
@@ -355,16 +355,16 @@
         },
         {
             "name": "nikic/php-parser",
-            "version": "v4.10.0",
+            "version": "v4.10.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/nikic/PHP-Parser.git",
-                "reference": "1c13d05035deff45f1230ca68bd7d74d621762d9"
+                "reference": "1b479e7592812411c20c34d9ed33db3957bde66e"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/nikic/PHP-Parser/zipball/1c13d05035deff45f1230ca68bd7d74d621762d9",
-                "reference": "1c13d05035deff45f1230ca68bd7d74d621762d9",
+                "url": "https://api.github.com/repos/nikic/PHP-Parser/zipball/1b479e7592812411c20c34d9ed33db3957bde66e",
+                "reference": "1b479e7592812411c20c34d9ed33db3957bde66e",
                 "shasum": ""
             },
             "require": {
@@ -403,7 +403,7 @@
                 "parser",
                 "php"
             ],
-            "time": "2020-09-19T14:52:48+00:00"
+            "time": "2020-09-23T18:23:49+00:00"
         },
         {
             "name": "padraic/humbug_get_contents",


### PR DESCRIPTION
This signals that master will be used to produce new 2.x releases
rather than 1.x. Practically speaking, it means that a `^2` dependency
Will start pulling in dev-master prior to a stable tag being provided,
as long as min-stability is set on the project requesting this.